### PR TITLE
Add queue system for sequential training jobs

### DIFF
--- a/jobs/TrainJob.py
+++ b/jobs/TrainJob.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+from queue import Queue
 
 from jobs import BaseJob
 from toolkit.kohya_model_util import load_models_from_stable_diffusion_checkpoint
@@ -20,6 +22,36 @@ process_dict = {
 }
 
 
+class _TrainingJobQueue:
+    """Simple queue to ensure training jobs run sequentially."""
+
+    def __init__(self):
+        # Queue of (job, event) pairs. The event is set when the job finishes.
+        self._queue = Queue()
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
+    def enqueue(self, job: "TrainJob"):
+        done = threading.Event()
+        # Add job to the queue and wait until it is executed
+        self._queue.put((job, done))
+        done.wait()
+
+    def _worker_loop(self):
+        while True:
+            job, done = self._queue.get()
+            try:
+                job._execute()
+            finally:
+                # Signal the waiting thread that the job finished
+                done.set()
+                self._queue.task_done()
+
+
+# Global queue instance used by all TrainJob instances
+_training_job_queue = _TrainingJobQueue()
+
+
 class TrainJob(BaseJob):
 
     def __init__(self, config: OrderedDict):
@@ -34,8 +66,12 @@ class TrainJob(BaseJob):
         # loads the processes from the config
         self.load_processes(process_dict)
 
-
     def run(self):
+        """Add the job to the global training queue and wait for completion."""
+        _training_job_queue.enqueue(self)
+
+    # internal method executed by the queue worker
+    def _execute(self):
         super().run()
         print("")
         print(f"Running  {len(self.process)} process{'' if len(self.process) == 1 else 'es'}")


### PR DESCRIPTION
## Summary
- ensure training jobs run sequentially using a global job queue
- delegate TrainJob.run to queue and execute via internal worker

## Testing
- `pytest` *(fails: libGL.so.1 missing, VAE model files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af958ab1a88325a6901dda6f1bf482