### PR TITLE
Queue training job launches in UI

### DIFF
--- a/jobs/TrainJob.py
+++ b/jobs/TrainJob.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+from queue import Queue
 
 from jobs import BaseJob
 from toolkit.kohya_model_util import load_models_from_stable_diffusion_checkpoint
@@ -20,6 +22,36 @@ process_dict = {
 }
 
 
+class _TrainingJobQueue:
+    """Simple queue to ensure training jobs run sequentially."""
+
+    def __init__(self):
+        # Queue of (job, event) pairs. The event is set when the job finishes.
+        self._queue = Queue()
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
+    def enqueue(self, job: "TrainJob"):
+        done = threading.Event()
+        # Add job to the queue and wait until it is executed
+        self._queue.put((job, done))
+        done.wait()
+
+    def _worker_loop(self):
+        while True:
+            job, done = self._queue.get()
+            try:
+                job._execute()
+            finally:
+                # Signal the waiting thread that the job finished
+                done.set()
+                self._queue.task_done()
+
+
+# Global queue instance used by all TrainJob instances
+_training_job_queue = _TrainingJobQueue()
+
+
 class TrainJob(BaseJob):
 
     def __init__(self, config: OrderedDict):
@@ -34,8 +66,12 @@ class TrainJob(BaseJob):
         # loads the processes from the config
         self.load_processes(process_dict)
 
-
     def run(self):
+        """Add the job to the global training queue and wait for completion."""
+        _training_job_queue.enqueue(self)
+
+    # internal method executed by the queue worker
+    def _execute(self):
         super().run()
         print("")
         print(f"Running  {len(self.process)} process{'' if len(self.process) == 1 else 'es'}")

--- a/ui/src/app/api/jobs/[jobID]/start/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/start/route.ts
@@ -10,6 +10,17 @@ const isWindows = process.platform === 'win32';
 
 const prisma = new PrismaClient();
 
+async function startNextQueuedJob() {
+  const nextJob = await prisma.job.findFirst({
+    where: { status: 'queued' },
+    orderBy: { updated_at: 'asc' },
+  });
+  if (nextJob) {
+    // call this route again to start the next job in queue
+    await GET(new NextRequest(''), { params: { jobID: nextJob.id } });
+  }
+}
+
 export async function GET(request: NextRequest, { params }: { params: { jobID: string } }) {
   const { jobID } = await params;
 
@@ -19,6 +30,21 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
 
   if (!job) {
     return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // if any job is currently running or queued, place this job in queue
+  const activeJob = await prisma.job.findFirst({
+    where: { status: { in: ['running'] } },
+  });
+  const queuedJob = await prisma.job.findFirst({
+    where: { status: 'queued' },
+  });
+  if (activeJob || queuedJob) {
+    await prisma.job.update({
+      where: { id: jobID },
+      data: { status: 'queued', info: 'Waiting in queue...' },
+    });
+    return NextResponse.json({ queued: true });
   }
 
   // update job status to 'running'
@@ -175,6 +201,8 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
             },
           });
         }
+        // after this job ends, start the next one in queue
+        await startNextQueuedJob();
       });
 
       // Wait 30 seconds before releasing the process

--- a/ui/src/components/JobOverview.tsx
+++ b/ui/src/components/JobOverview.tsx
@@ -69,6 +69,8 @@ export default function JobOverview({ job }: JobOverviewProps) {
         return 'bg-blue-500/10 text-blue-500';
       case 'error':
         return 'bg-rose-500/10 text-rose-500';
+      case 'queued':
+        return 'bg-amber-500/10 text-amber-500';
       default:
         return 'bg-gray-500/10 text-gray-400';
     }

--- a/ui/src/components/JobsTable.tsx
+++ b/ui/src/components/JobsTable.tsx
@@ -56,6 +56,7 @@ export default function JobsTable({ onlyActive = false }: JobsTableProps) {
         if (row.status === 'completed') statusClass = 'text-green-400';
         if (row.status === 'failed') statusClass = 'text-red-400';
         if (row.status === 'running') statusClass = 'text-blue-400';
+        if (row.status === 'queued') statusClass = 'text-yellow-400';
 
         return <span className={statusClass}>{row.status}</span>;
       },

--- a/ui/src/utils/jobs.ts
+++ b/ui/src/utils/jobs.ts
@@ -57,8 +57,8 @@ export const getJobConfig = (job: Job) => {
 export const getAvaliableJobActions = (job: Job) => {
   const jobConfig = getJobConfig(job);
   const isStopping = job.stop && job.status === 'running';
-  const canDelete = ['completed', 'stopped', 'error'].includes(job.status) && !isStopping;
-  const canEdit = ['completed', 'stopped', 'error'].includes(job.status) && !isStopping;
+  const canDelete = ['completed', 'stopped', 'error', 'queued'].includes(job.status) && !isStopping;
+  const canEdit = ['completed', 'stopped', 'error', 'queued'].includes(job.status) && !isStopping;
   const canStop = job.status === 'running' && !isStopping;
   let canStart = ['stopped', 'error'].includes(job.status) && !isStopping;
   // can resume if more steps were added


### PR DESCRIPTION
## Summary
- queue training job launches when another job is active
- show queued state for jobs in tables and job overview
- allow job actions while queued

## Testing
- `npm run lint` *(interactive ESLint prompt)*
- `pytest` *(FileNotFoundError: /mnt/Models/stable-diffusion/.../vae-ft-mse-840000-ema-pruned.safetensors)*

------
https://chatgpt.com/codex/tasks/task_e_68af958ab1a88325a6901dda6f1bf482