### PR TITLE
Queue training job launches in UI

### DIFF
--- a/jobs/TrainJob.py
+++ b/jobs/TrainJob.py
@@ -34,7 +34,6 @@ class TrainJob(BaseJob):
         # loads the processes from the config
         self.load_processes(process_dict)
 
-
     def run(self):
         super().run()
         print("")

--- a/ui/src/app/api/jobs/[jobID]/start/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/start/route.ts
@@ -4,7 +4,6 @@ import { TOOLKIT_ROOT } from '@/paths';
 import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import { getTrainingFolder, getHFToken } from '@/server/settings';
 const isWindows = process.platform === 'win32';
 
@@ -19,6 +18,22 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
 
   if (!job) {
     return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // if any job is currently running or an earlier job is queued, place this job in queue
+  const runningJob = await prisma.job.findFirst({
+    where: { status: 'running' },
+  });
+  const firstQueuedJob = await prisma.job.findFirst({
+    where: { status: 'queued' },
+    orderBy: { updated_at: 'asc' },
+  });
+  if (runningJob || (firstQueuedJob && firstQueuedJob.id !== jobID)) {
+    await prisma.job.update({
+      where: { id: jobID },
+      data: { status: 'queued', info: 'Waiting in queue...' },
+    });
+    return NextResponse.json({ queued: true });
   }
 
   // update job status to 'running'

--- a/ui/src/components/JobOverview.tsx
+++ b/ui/src/components/JobOverview.tsx
@@ -69,6 +69,8 @@ export default function JobOverview({ job }: JobOverviewProps) {
         return 'bg-blue-500/10 text-blue-500';
       case 'error':
         return 'bg-rose-500/10 text-rose-500';
+      case 'queued':
+        return 'bg-amber-500/10 text-amber-500';
       default:
         return 'bg-gray-500/10 text-gray-400';
     }

--- a/ui/src/components/JobsTable.tsx
+++ b/ui/src/components/JobsTable.tsx
@@ -9,7 +9,7 @@ interface JobsTableProps {
 }
 
 export default function JobsTable({ onlyActive = false }: JobsTableProps) {
-  const { jobs, status, refreshJobs } = useJobsList(onlyActive);
+  const { jobs, status, refreshJobs } = useJobsList(onlyActive, 5000);
   const isLoading = status === 'loading';
 
   const columns: TableColumn[] = [
@@ -56,6 +56,7 @@ export default function JobsTable({ onlyActive = false }: JobsTableProps) {
         if (row.status === 'completed') statusClass = 'text-green-400';
         if (row.status === 'failed') statusClass = 'text-red-400';
         if (row.status === 'running') statusClass = 'text-blue-400';
+        if (row.status === 'queued') statusClass = 'text-yellow-400';
 
         return <span className={statusClass}>{row.status}</span>;
       },

--- a/ui/src/hooks/useJobsList.tsx
+++ b/ui/src/hooks/useJobsList.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { Job } from '@prisma/client';
 import { apiClient } from '@/utils/api';
+import { startJob } from '@/utils/jobs';
 
-export default function useJobsList(onlyActive = false) {
+export default function useJobsList(onlyActive = false, reloadInterval: number | null = null) {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
 
-  const refreshJobs = () => {
+  const refreshJobs = useCallback(() => {
     setStatus('loading');
     apiClient
       .get('/api/jobs')
@@ -30,10 +31,41 @@ export default function useJobsList(onlyActive = false) {
         console.error('Error fetching datasets:', error);
         setStatus('error');
       });
-  };
+  }, [onlyActive]);
   useEffect(() => {
     refreshJobs();
-  }, []);
+
+    if (reloadInterval) {
+      const interval = setInterval(() => {
+        refreshJobs();
+      }, reloadInterval);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [reloadInterval, onlyActive, refreshJobs]);
+
+  const startingRef = useRef(false);
+
+  useEffect(() => {
+    if (startingRef.current) return;
+    const running = jobs.some(job => job.status === 'running');
+    if (!running) {
+      const next = jobs.find(job => job.status === 'queued');
+      if (next) {
+        startingRef.current = true;
+        startJob(next.id)
+          .catch(() => {
+            // ignore errors; will retry on next refresh
+          })
+          .finally(() => {
+            startingRef.current = false;
+            refreshJobs();
+          });
+      }
+    }
+  }, [jobs, refreshJobs]);
 
   return { jobs, setJobs, status, refreshJobs };
 }

--- a/ui/src/utils/jobs.ts
+++ b/ui/src/utils/jobs.ts
@@ -57,8 +57,8 @@ export const getJobConfig = (job: Job) => {
 export const getAvaliableJobActions = (job: Job) => {
   const jobConfig = getJobConfig(job);
   const isStopping = job.stop && job.status === 'running';
-  const canDelete = ['completed', 'stopped', 'error'].includes(job.status) && !isStopping;
-  const canEdit = ['completed', 'stopped', 'error'].includes(job.status) && !isStopping;
+  const canDelete = ['completed', 'stopped', 'error', 'queued'].includes(job.status) && !isStopping;
+  const canEdit = ['completed', 'stopped', 'error', 'queued'].includes(job.status) && !isStopping;
   const canStop = job.status === 'running' && !isStopping;
   let canStart = ['stopped', 'error'].includes(job.status) && !isStopping;
   // can resume if more steps were added


### PR DESCRIPTION
## Summary
- remove backend training job queue and rely on UI to serialize launches
- fix malformed URL error in training job start route
- auto-start next queued job from polling hook when no job is running
- rename duplicate `activeJob` variable in start route to avoid build error

## Testing
- `npm run lint` *(interactive configuration prompt)*
- `pytest` *(FileNotFoundError: No such file or directory: /mnt/Models/stable-diffusion/models/VAE/vae-ft-mse-840000-ema-pruned/vae-ft-mse-840000-ema-pruned.safetensors)*

------
https://chatgpt.com/codex/tasks/task_e_68af958ab1a88325a6901dda6f1bf482